### PR TITLE
Add CacheControl Response header

### DIFF
--- a/source/app/public/admin-src/scss/main.scss
+++ b/source/app/public/admin-src/scss/main.scss
@@ -1,5 +1,3 @@
-@config "../tailwind.config.js"
-
 body {
     font-family: 'Roboto', 'Noto Sans JP', sans-serif;
 }

--- a/source/app/public/admin-src/scss/main.scss
+++ b/source/app/public/admin-src/scss/main.scss
@@ -1,3 +1,5 @@
+@config "../tailwind.config.js"
+
 body {
     font-family: 'Roboto', 'Noto Sans JP', sans-serif;
 }

--- a/source/app/src/Handler/Download.php
+++ b/source/app/src/Handler/Download.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace MyVendor\MyPackage\Handler;
 
 use AppCore\Exception\RuntimeException;
+use Koriym\HttpConstants\CacheControl;
+use Koriym\HttpConstants\ResponseHeader;
 use MyVendor\MyPackage\RequestHandler;
 
+use function array_merge;
 use function fopen;
 use function fputcsv;
 
 final class Download extends RequestHandler
 {
+    /** @var array<string, string> */
+    public array $headers = [ResponseHeader::CACHE_CONTROL => CacheControl::NO_STORE];
+
     public function onGet(): self
     {
         $stream = fopen('php://temp', 'wb');
@@ -19,11 +25,11 @@ final class Download extends RequestHandler
             throw new RuntimeException();
         }
 
-        $this->headers = [
+        $this->headers = array_merge($this->headers, [
             'Content-Type' => 'application/octet-stream',
             'Content-Disposition' => 'attachment; filename=dummy.csv',
             'Content-Transfer-Encoding' => 'binary',
-        ];
+        ]);
         $this->stream = $stream;
 
         fputcsv($stream, [

--- a/source/app/src/Handler/Hello.php
+++ b/source/app/src/Handler/Hello.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace MyVendor\MyPackage\Handler;
 
+use Koriym\HttpConstants\CacheControl;
+use Koriym\HttpConstants\ResponseHeader;
 use MyVendor\MyPackage\RequestHandler;
 
 final class Hello extends RequestHandler
 {
+    /** @var array<string, string> */
+    public array $headers = [ResponseHeader::CACHE_CONTROL => CacheControl::PUBLIC_ . ',max-age=86400'];
+
     public function onGet(): self
     {
         $this->body['Hello'] = 'world';

--- a/source/app/src/RequestHandler.php
+++ b/source/app/src/RequestHandler.php
@@ -10,13 +10,13 @@ use Stringable;
 
 class RequestHandler implements Stringable
 {
-    /** @var int<200, max>  */
+    /** @var int<200, max> */
     public int $code = StatusCode::OK;
 
-    /** @var array<string, string>  */
+    /** @var array<string, string> */
     public array $headers = [];
 
-    /** @var array<string, mixed>|null  */
+    /** @var array<string, mixed>|null */
     public array|null $body = null;
 
     /** @var resource|null */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added cache control headers to `Download` and `Hello` handlers
	- Introduced `$headers` property in both handler classes to manage HTTP response headers

- **Documentation**
	- Updated PHPDoc comments for `RequestHandler` class properties, improving code formatting and consistency

The changes enhance header management and improve code documentation in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->