### PR TITLE
Fix RequestDispatcher

### DIFF
--- a/source/app/src/RequestDispatcher.php
+++ b/source/app/src/RequestDispatcher.php
@@ -198,6 +198,9 @@ final class RequestDispatcher
         assert($renderer instanceof RendererInterface);
 
         $response = $this->responseFactory->createResponse();
+
+        $view = $renderer->render($object);
+
         foreach ($object->headers as $name => $value) {
             $response = $response->withHeader($name, $value);
         }
@@ -208,7 +211,7 @@ final class RequestDispatcher
             return $response->withStatus($object->code);
         }
 
-        $response = $response->withBody($this->streamFactory->createStream($renderer->render($object)));
+        $response = $response->withBody($this->streamFactory->createStream($view));
 
         return $response->withStatus($object->code);
     }

--- a/source/app/src/RequestDispatcher.php
+++ b/source/app/src/RequestDispatcher.php
@@ -199,7 +199,7 @@ final class RequestDispatcher
 
         $response = $this->responseFactory->createResponse();
 
-        $view = $renderer->render($object);
+        $body = $renderer->render($object);
 
         foreach ($object->headers as $name => $value) {
             $response = $response->withHeader($name, $value);
@@ -211,7 +211,7 @@ final class RequestDispatcher
             return $response->withStatus($object->code);
         }
 
-        $response = $response->withBody($this->streamFactory->createStream($view));
+        $response = $response->withBody($this->streamFactory->createStream($body));
 
         return $response->withStatus($object->code);
     }


### PR DESCRIPTION
## Sourcery によるサマリー

バグ修正:
- レンダリングされたビューを変数に格納し、レスポンスボディにそれを使用することで、二重レンダリングを防ぎます。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Store the rendered view in a variable and use it for the response body to prevent double rendering

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved performance by optimizing how view rendering is handled during response creation, reducing redundant rendering operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->